### PR TITLE
Various enhancements to the gRPC example.

### DIFF
--- a/language-examples/java/grpc/src/main/java/com/vectara/examples/grpc/GrpcArgs.java
+++ b/language-examples/java/grpc/src/main/java/com/vectara/examples/grpc/GrpcArgs.java
@@ -8,13 +8,13 @@ class GrpcArgs {
       names = {"--customer-id"},
       description = "Unique customer ID in Vectara platform.",
       required = true)
-  Long customerId = 1890073338L;
+  Long customerId = null;
 
   @Parameter(
       names = {"--corpus-id"},
       description = "Corpus ID against which examples need to be run.",
       required = true)
-  Long corpusId = 321L;
+  Long corpusId = 1L;
 
   @Parameter(
       names = {"--admin-endpoint"},
@@ -39,13 +39,15 @@ class GrpcArgs {
 
   @Parameter(
       names = {"--app-client-id"},
-      description = "App Client ID retrieved from Vectara console.")
-  String appClientId;
+      description = "App Client ID retrieved from Vectara console.",
+      required = true)
+  @Nullable String appClientId;
 
   @Parameter(
       names = {"--app-client-secret"},
-      description = "App client secret retrieved from Vectara console.")
-  String appClientSecret;
+      description = "App client secret retrieved from Vectara console.",
+      required = true)
+  @Nullable String appClientSecret;
 
   @Parameter(
       names= {"--api-key"},

--- a/language-examples/java/grpc/src/main/java/com/vectara/examples/grpc/GrpcBasicOperations.java
+++ b/language-examples/java/grpc/src/main/java/com/vectara/examples/grpc/GrpcBasicOperations.java
@@ -23,6 +23,7 @@ import com.beust.jcommander.JCommander;
 import com.vectara.auth.JwtFetcher;
 import com.vectara.auth.VectaraCallCredentials;
 import com.vectara.auth.VectaraCallCredentials.AuthType;
+import com.vectara.serving.ServingProtos.QueryRequest.ContextConfig;
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
 import io.grpc.netty.GrpcSslContexts;
@@ -77,7 +78,8 @@ public class GrpcBasicOperations {
     // It takes some time to index data in Vectara platform. It is possible that query will
     // return zero results immediately after indexing. Please wait 3-5 minutes and try again if
     // that happens.
-    result = queryData(jwtToken, args.servingEndpoint, "test", args.customerId, args.corpusId);
+    result = queryData(
+        jwtToken, args.servingEndpoint, "How long ago was it?", args.customerId, args.corpusId);
     if (!result) {
       LOGGER.log(Level.SEVERE, "Querying failed. Please see previous logs for details.");
       System.exit(1);
@@ -245,7 +247,8 @@ public class GrpcBasicOperations {
                                                               customerId,
                                                               corpusId))
               .query(builder.build());
-      LOGGER.info(String.format("Querying response: %s", response.toString()));
+      LOGGER.info(
+          String.format("Query <%s> response:\n%s", query, response.toString()));
       return true;
     } catch (SSLException e) {
       LOGGER.log(Level.SEVERE, String.format("Error while querying data: %s", e));


### PR DESCRIPTION
Various usability enhancements to gRPC getting started for Java:

1. Customer ID should be null, the current default doesn't make sense.
2. Corpus ID should be defaulted to 1 because for a new account, that's the most logical choice.
3. app-client and app-secret should be required. Without them indexing will crash. Once we have read-write API keys, this can be adjusted.
4. If command line parameters are missing, print the error message cleanly (previously was printing an ugly stack trace), and also print program usage guide.
5. Infer the auth URL from the customer account number if it's not explicitly set (ease-of-use)
6. Put in a more realistic document (Gettysburg Address), with realistic metadata. This gives the user better insight into how the platform can be used.
7. Put in a more realistic query (was "test"). Again, this helps the user.
8. Improve formatting of server response.