### PR TITLE
Fixed a variety of issues in GrpcApiKeyQueries.java

### DIFF
--- a/language-examples/java/grpc/README.md
+++ b/language-examples/java/grpc/README.md
@@ -8,9 +8,13 @@ The Vectara APIs are divided into three parts:
 * Serving (Or Querying)
 * Admin
 
-This logical separation requires an API user to connect to them with different parameters.
-This example will give an idea of what parameters to pass and what needs to be done in 
-order to be able to successfully call these APIs.
+This separation requires API users to connect to each separately. The examples in this
+directory demonstrate how to connect to and use all three APIs via gRPC. Specifically, they
+demonstrate the following functionality:
+
+1. Creating a corpus using OAuth.
+2. Indexing data into a corpus using OAuth.
+3. Querying a corpus using both OAuth and API Keys.
 
 ### Authentication
 
@@ -23,10 +27,16 @@ Please see the details here: [Authentication](../../../README.md).
 Following are the steps that need to be done to run this example:
 
 1. Clone the repo (Please see details here: [cloning guidelines](../../../README.md)).
-2. cd to 'vectara-java-demo/java/auth' directory and run `mvn install`. This will build the 
-authentication library and will make it available for subsequent projects.
-3. cd to `vectara-java-demo/java/grpc` directory.
-4. run `mvn package` (This will create a target directory with a shaded JAR)
+2. Build the authentication library and make it available for subsequent projects.
+   ```shell
+   cd language-examples/java/auth
+   mvn install
+   ```
+3. Build the gRPC example. This will create a target directory with a shaded JAR.
+   ```shell
+   cd language-examples/java/grpc
+   mvn package
+   ```
 5. Run the jar file with a command like following:
 
     a. If you are using OAuth2 as the authentication method:
@@ -43,14 +53,11 @@ authentication library and will make it available for subsequent projects.
        java -cp target/grpc-1.0-SNAPSHOT.jar com.vectara.examples.grpc.GrpcApiKeyQueries \
          --customer-id ${YOUR_CUSTOMER_ID} \
          --corpus-id ${YOUR_CORPUS_ID} \
-         --api-key "${YOUR_API_KEY}"
+         --api-key "${YOUR_API_KEY}" \
+         --query "What is the meaning of life?"
     ```
-> Please note the double quotes in the arguments, which indicate a string argument.
+Note the double quotes in the arguments, which indicate a string argument.
 
-### Functionality exercised
+You can run GrpcApiKeyQueries with the `--help` option to obtain a comprehensive list of command 
+line arguments.
 
-The examples in this directory exercise the following functionality:
-
-1. Creating a corpus using OAuth.
-2. Indexing data into a corpus using OAuth.
-3. Querying a corpus using both OAuth and API Keys.

--- a/language-examples/java/grpc/README.md
+++ b/language-examples/java/grpc/README.md
@@ -1,6 +1,6 @@
 # README #
 
-### Calling Vectara API via gRPC ###
+### Calling the Vectara API via gRPC ###
 
 The Vectara APIs are divided into three parts:
 
@@ -18,8 +18,9 @@ demonstrate the following functionality:
 
 ### Authentication
 
-There are two supported authentication methods Vectara. 
-Please see the details here: [Authentication](../../../README.md).
+Vectara supports OAuth2 and API Key authentication methods. For details, please visit
+[docs.vectara.com](https://docs.vectara.com). You can also find more information in this
+repository's top-level [README](../../../README.md) file.
 
 ### Running the Example
 > This example is built with JDK 11. To run this example, JDK 11 needs to be installed and discoverable.
@@ -37,9 +38,11 @@ Following are the steps that need to be done to run this example:
    cd language-examples/java/grpc
    mvn package
    ```
-5. Run the jar file with a command like following:
+5. Run the jar file with either of the commands below, depending on the authentication
+   method you are using:
 
-    a. If you are using OAuth2 as the authentication method:
+    a. If you are using [OAuth2](https://docs.vectara.com/docs/api-reference/auth-apis/oauth-2) as 
+       the authentication method:
     ```shell
        java -cp target/grpc-1.0-SNAPSHOT.jar com.vectara.examples.grpc.GrpcBasicOperations \
          --customer-id ${YOUR_CUSTOMER_ID} \
@@ -48,7 +51,8 @@ Following are the steps that need to be done to run this example:
          --app-client-id "${YOUR_APPCLIENT_ID}" \
          --app-client-secret "${YOUR_APPCLIENT_SECRET}"
     ```
-    b. If you are using an API key as the authentication method:
+    b. If you are using an [API key](https://docs.vectara.com/docs/common-use-cases/app-authn-authz/api-keys)
+       as the authentication method:
     ```shell
        java -cp target/grpc-1.0-SNAPSHOT.jar com.vectara.examples.grpc.GrpcApiKeyQueries \
          --customer-id ${YOUR_CUSTOMER_ID} \


### PR DESCRIPTION
1. Readme had several outdated directory names. Did a readability pass.
2. Command line parameters were wrong. For example, oauth information was required for the API key example. I cloned the args and trimmed out whatever was unneeded. I also marked the API key parameter as required.
3. No way to set the port number, added that.
4. Ability to override the certificate. This is rarely needed, and default is sane.
5. Made query data more copy-pastable because it returns the batch response, rather than printing and returning a bool.
6. Allow the query to be set. This makes the class much more useful.