### PR TITLE
Fix php examples

### DIFF
--- a/language-examples/php/grpc/composer.json
+++ b/language-examples/php/grpc/composer.json
@@ -1,16 +1,16 @@
 {
-    "name": "grpc/grpc-demo",
-    "description": "gRPC example for PHP",
-    "require": {
-      "grpc/grpc": "^v1.30.0",
-      "google/protobuf": "^v3.12.2",
-      "google/common-protos": "^2.0",
-      "league/oauth2-client": "^2.6.1"
-    },
-    "autoload": {
-      "psr-4": {
-        "Com\\": "Com/",
-        "GPBMetadata\\": "GPBMetadata/"
-      }
+  "name": "grpc/grpc-demo",
+  "description": "gRPC example for PHP",
+  "require": {
+    "grpc/grpc": "^1.38",
+    "google/protobuf": "^v3.12.2",
+    "google/common-protos": "^2.0",
+    "league/oauth2-client": "^2.6.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Com\\": "Com/",
+      "GPBMetadata\\": "GPBMetadata/"
     }
   }
+}

--- a/language-examples/php/grpc/deleteDocument.php
+++ b/language-examples/php/grpc/deleteDocument.php
@@ -55,12 +55,9 @@ if ($status->code !== Grpc\STATUS_OK) {
     exit(1);
 }
 
-if ($result->getStatus()->getCode() === 0) {
+if ($status->code === 0) {
     echo 'SUCCESS: Document deleted';
 } else {
-    echo 'ERROR: Code: ' .
-        $result->getStatus()->getCode() .
-        ' Detail: ' .
-        $result->getStatus()->getStatusDetail();
+    echo 'ERROR: Could not delete document, Status Code: '. $status->code;
 }
 ?>

--- a/language-examples/php/grpc/getJwtToken.php
+++ b/language-examples/php/grpc/getJwtToken.php
@@ -13,6 +13,8 @@ require __DIR__ . '/vendor/autoload.php';
 
 function get_token($auth_url, $client_id, $client_secret)
 {
+    // remove any path from auth_url and keep only the domain
+    $auth_url = parse_url($auth_url, PHP_URL_SCHEME) . '://' . parse_url($auth_url, PHP_URL_HOST);
     $provider = new \League\OAuth2\Client\Provider\GenericProvider([
         'clientId' => $client_id,
         'clientSecret' => $client_secret,

--- a/language-examples/php/rest/getJwtToken.php
+++ b/language-examples/php/rest/getJwtToken.php
@@ -10,18 +10,24 @@
  */
 function get_token($auth_url, $client_id, $client_secret)
 {
-    $url = $auth_url . '/oauth2/token';
-    $encoded = base64_encode($client_id . ':' . $client_secret);
+    //remove trialing / from auth_url
+    $url = rtrim($auth_url, '/');
+
+    // append /oauth2/token to the auth_url if it does not end with it 
+    if (!str_ends_with($url, '/oauth2/token')) {
+        $auth_url .= '/oauth2/token';
+    }
 
     $fields = [
         'grant_type' => 'client_credentials',
         'client_id' => $client_id,
+        'client_secret' => $client_secret
     ];
 
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_POST, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Authorization: Basic ' . $encoded]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type', 'application/x-www-form-urlencoded']);
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($fields));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 

--- a/language-examples/php/rest/getJwtToken.php
+++ b/language-examples/php/rest/getJwtToken.php
@@ -27,7 +27,7 @@ function get_token($auth_url, $client_id, $client_secret)
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);
     curl_setopt($ch, CURLOPT_POST, true);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type', 'application/x-www-form-urlencoded']);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/x-www-form-urlencoded']);
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($fields));
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 


### PR DESCRIPTION
Fixes PHP examples 

1. Fix the JWT fetcher method for the Rest
2. Fix the JWT fetcher for gRPC
3. Fixes the response in gRPC examples of DeleteDocument, as that does not contain response code